### PR TITLE
wip: parse CST into AST

### DIFF
--- a/lang/Cargo.lock
+++ b/lang/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "cstree"
 version = "0.12.1"
-source = "git+https://github.com/jyn514/cstree?rev=6116e41806e7fce57e1cc078c19d117c3e0b5075#6116e41806e7fce57e1cc078c19d117c3e0b5075"
+source = "git+https://github.com/domenicquirl/cstree?rev=00901a8e52c1bd27c59727e11e1960be069d8f4e#00901a8e52c1bd27c59727e11e1960be069d8f4e"
 dependencies = [
  "fxhash",
  "indexmap",
@@ -376,8 +376,13 @@ dependencies = [
  "colored",
  "cstree",
  "ctrlc",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
  "serde_json",
+ "syn",
  "ui_test",
+ "ungrammar",
  "xshell",
 ]
 
@@ -518,10 +523,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.87"
+name = "prettyplease"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -733,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -853,6 +868,12 @@ dependencies = [
  "serde_json",
  "spanned",
 ]
+
+[[package]]
+name = "ungrammar"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e5df347f0bf3ec1d670aad6ca5c6a1859cd9ea61d2113125794654ccced68f"
 
 [[package]]
 name = "unicode-ident"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lang"
 version = "0.1.0"
 edition = "2021"
+build = "codegen/main.rs"
 
 [dependencies]
 annotate-snippets = "0.11.4"
@@ -9,7 +10,7 @@ annotate-snippets = "0.11.4"
 chumsky = { git = "https://github.com/jyn514/chumsky", rev = "8baf2151f0e8e5904847056b7bde0d06a2be8dee", version = "1.0.0-alpha.7", features = ["extension"] }
 colored = "2.1.0"
 # rowan = "0.15.16"
-cstree = { git = "https://github.com/jyn514/cstree", rev = "6116e41806e7fce57e1cc078c19d117c3e0b5075", version = "0.12" }
+cstree = { git = "https://github.com/domenicquirl/cstree", rev = "00901a8e52c1bd27c59727e11e1960be069d8f4e", version = "0.12" }
 
 [dev-dependencies]
 ctrlc = "3.4.5"
@@ -21,3 +22,10 @@ cargo_metadata = "0.18.1"
 [[test]]
 name = "ui_test"
 harness = false
+
+[build-dependencies]
+prettyplease = "0.2.24"
+proc-macro2 = "1.0.88"
+quote = "1.0.37"
+syn = "2.0.82"
+ungrammar = "1.16.1"

--- a/lang/codegen/ast.ungram
+++ b/lang/codegen/ast.ungram
@@ -1,0 +1,24 @@
+SourceFile =
+  Statement*
+
+Statement =
+  Alias
+| Assign
+
+Alias = 'alias' '#ident' '=' Place
+
+Assign = Place '=' Expr
+
+Expr =
+  Enum
+| Place
+| '#int'
+| '#str'
+
+Enum = 'enum' Place
+
+Place =
+  '#cell'
+| CellRange
+
+CellRange = start:'#cell' ':' end:'#cell'

--- a/lang/codegen/main.rs
+++ b/lang/codegen/main.rs
@@ -1,0 +1,277 @@
+use std::path::Path;
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse2;
+use ungrammar::{Grammar, Node, Rule};
+
+fn main() {
+    let grammar: Grammar = include_str!("ast.ungram").parse().unwrap();
+    let mut walker = GrammarWalker {
+        ast: AstSrc::default(),
+    };
+    for n in grammar.iter() {
+        walker.lower_node(&grammar, n);
+    }
+    println!("{:?}", walker.ast.nodes);
+    let src = generate(walker.ast);
+    println!("{src}");
+    let pretty = prettyplease::unparse(&parse2(src).unwrap());
+    println!("{pretty}");
+    let dst = Path::new(&std::env::var("OUT_DIR").unwrap()).join("ast.rs");
+    std::fs::write(dst, pretty).unwrap();
+}
+
+/// It's hard to generate tokens as-we-go. Instead add an IR for items in the ungrammar.
+///
+/// I really wish this were part of `ungrammar` itself...
+#[derive(Default, Debug)]
+struct AstSrc {
+    // tokens: Vec<String>,
+    nodes: Vec<AstItem>,
+}
+
+#[derive(Debug)]
+struct AstItem {
+    name: String,
+    kind: AstItemKind,
+}
+
+#[derive(Debug)]
+enum AstItemKind {
+    Struct(Vec<Field>),
+    Enum(Vec<Variant>),
+}
+
+#[derive(Debug)]
+enum Variant {
+    Token(String),
+    Node(String),
+}
+
+#[derive(Debug)]
+enum Field {
+    Token(String),
+    Node {
+        label: String,
+        ty: String,
+        cardinality: Cardinality,
+    },
+}
+
+#[derive(Debug)]
+enum Cardinality {
+    /// When we recover from errors we may not have some of the fields
+    Optional,
+    Many,
+}
+
+use Cardinality::*;
+
+struct GrammarWalker {
+    ast: AstSrc,
+}
+
+impl GrammarWalker {
+    fn lower_node(&mut self, grammar: &Grammar, n: Node) {
+        let mut acc = vec![];
+        let node = &grammar[n];
+        self.lower_rule(grammar, &mut acc, &node.rule, &node.name, None);
+        if acc.is_empty() {
+            return; // this was an enum
+        }
+        self.ast.nodes.push(AstItem {
+            name: node.name.clone(),
+            kind: AstItemKind::Struct(acc),
+        });
+    }
+
+    fn lower_rule(
+        &mut self,
+        grammar: &Grammar,
+        acc: &mut Vec<Field>,
+        rule: &Rule,
+        name: &str,
+        label: Option<&str>,
+    ) {
+        let field = match *rule {
+            Rule::Labeled {
+                ref label,
+                ref rule,
+            } => {
+                self.lower_rule(grammar, acc, rule, name, Some(label));
+                return;
+            }
+            Rule::Node(n) => {
+                let nested = &grammar[n];
+                let name = match label {
+                    Some(s) => s.into(),
+                    None => to_lower_snake_case(&nested.name),
+                };
+                Field::Node {
+                    label: name,
+                    ty: nested.name.clone(),
+                    cardinality: Optional,
+                }
+            }
+            Rule::Token(t) => {
+                let token = &grammar[t];
+                let Some(kind) = token.name.strip_prefix('#') else {
+                    return;
+                };
+                let name = match label {
+                    Some(s) => s.into(),
+                    None => to_lower_snake_case(kind),
+                };
+                Field::Token(name)
+            }
+            Rule::Rep(ref inner) => {
+                if let Rule::Node(n) = **inner {
+                    let ty = &grammar[n].name;
+                    let name = match label {
+                        Some(s) => s.into(),
+                        None => pluralize(&to_lower_snake_case(&ty)),
+                    };
+                    Field::Node {
+                        label: name,
+                        ty: ty.into(),
+                        cardinality: Many,
+                    }
+                } else {
+                    panic!(
+                        "{}: unhandled Rule::Rep (repeated with '*'): {:?}\nInner: {:?}",
+                        name, rule, inner
+                    )
+                }
+            }
+            Rule::Alt(ref rules) => {
+                let mut variants = vec![];
+                for rule in rules {
+                    match *rule {
+                        Rule::Node(n) => {
+                            let ty = &grammar[n].name;
+                            variants.push(Variant::Node(ty.clone()));
+                        }
+                        Rule::Token(n) => {
+                            let ty = &grammar[n].name;
+                            if let Some(data) = ty.strip_prefix('#') {
+                                variants.push(Variant::Token(to_pascal_case(data)));
+                            }
+                        }
+                        _ => panic!("unhandled variant {rule:?} for enum {name}"),
+                    }
+                }
+                self.ast.nodes.push(AstItem {
+                    name: name.into(),
+                    kind: AstItemKind::Enum(variants),
+                });
+                return;
+            }
+            Rule::Opt(ref rule) => return self.lower_rule(grammar, acc, rule, name, label),
+            Rule::Seq(ref rules) => {
+                for rule in rules {
+                    self.lower_rule(grammar, acc, rule, name, label);
+                }
+                return;
+            }
+        };
+        acc.push(field);
+    }
+}
+
+fn generate(ast: AstSrc) -> TokenStream {
+    let mut acc = quote! { use ::cstree::green::GreenNode; };
+    for node in ast.nodes {
+        let name = format_ident!("{}", node.name);
+        let item = match node.kind {
+            AstItemKind::Struct(fields) => {
+                let fields = fields.iter().map(|f| match f {
+                    Field::Token(name) => {
+                        let name = format_ident!("{name}");
+                        quote! {
+                            #name: GreenNode,
+                        }
+                    }
+                    Field::Node {
+                        label: name,
+                        ty,
+                        cardinality,
+                    } => {
+                        let name = format_ident!("{name}");
+                        let ty = format_ident!("{ty}");
+                        let ty = match cardinality {
+                            Many => quote! { Vec<#ty> },
+                            Optional => quote! { Option<#ty> },
+                        };
+                        quote! {
+                           #name: #ty,
+                        }
+                    }
+                });
+                quote! {
+                   struct #name {
+                       #(#fields)*
+                   }
+                }
+            }
+            AstItemKind::Enum(variants) => {
+                let variants = variants.iter().map(|v| match v {
+                    Variant::Node(name) => {
+                        let name = format_ident!("{name}");
+                        quote! {
+                            #name(#name)
+                        }
+                    }
+                    Variant::Token(name) => {
+                        let name = format_ident!("{name}");
+                        quote! {
+                            #name(GreenNode)
+                        }
+                    }
+                });
+                quote! {
+                    enum #name {
+                        #(#variants),*
+                    }
+                }
+            }
+        };
+        acc.extend(item);
+    }
+    acc
+}
+
+// blatently taken from rust-analyzer
+fn pluralize(s: &str) -> String {
+    format!("{s}s")
+}
+
+fn to_lower_snake_case(s: &str) -> String {
+    let mut buf = String::with_capacity(s.len());
+    let mut prev = false;
+    for c in s.chars() {
+        if c.is_ascii_uppercase() && prev {
+            buf.push('_')
+        }
+        prev = true;
+
+        buf.push(c.to_ascii_lowercase());
+    }
+    buf
+}
+
+fn to_pascal_case(s: &str) -> String {
+    let mut buf = String::with_capacity(s.len());
+    let mut prev_is_underscore = true;
+    for c in s.chars() {
+        if c == '_' {
+            prev_is_underscore = true;
+        } else if prev_is_underscore {
+            buf.push(c.to_ascii_uppercase());
+            prev_is_underscore = false;
+        } else {
+            buf.push(c.to_ascii_lowercase());
+        }
+    }
+    buf
+}

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -1,3 +1,4 @@
+include!(concat!(env!("OUT_DIR"), "/ast.rs"));
 mod grammar;
 mod parser;
 pub use parser::parse;

--- a/lang/src/parser.rs
+++ b/lang/src/parser.rs
@@ -134,7 +134,7 @@ impl<'a> chumsky::recorder::Recorder<'a, &'a str> for RowanRecorder<'a> {
         &mut self,
         marker: chumsky::input::Marker<'a, 'parse, &'a str, Self::SaveMarker>,
     ) {
-        self.builder.revert(marker.ext_checkpoint())
+        self.builder.revert_to(marker.ext_checkpoint())
     }
 }
 


### PR DESCRIPTION
this is the part that generates the AST from an `ungrammar` file; i haven't actually done the parsing yet

i need to also set up tests that the generated file doesn't change. right now it looks like this
```rust
use ::cstree::green::GreenNode;
struct SourceFile {
    statements: Vec<Statement>,
}
enum Statement {
    Alias(Alias),
    Assign(Assign),
}
struct Alias {
    ident: GreenNode,
    place: Option<Place>,
}
struct Assign {
    place: Option<Place>,
    expr: Option<Expr>,
}
enum Place {
    Cell(GreenNode),
    CellRange(CellRange),
}
enum Expr {
    Enum(Enum),
    Place(Place),
    Int(GreenNode),
    Str(GreenNode),
}
struct Enum {
    place: Option<Place>,
}
struct CellRange {
    start: GreenNode,
    end: GreenNode,
}
```